### PR TITLE
Templates with support for python builtins

### DIFF
--- a/mailipy/gen.py
+++ b/mailipy/gen.py
@@ -35,10 +35,6 @@ BASE_HTML = """<!DOCTYPE html>
 </html>"""
 
 
-def render_template(template, data):
-    return jinja2.Environment(loader=jinja2.BaseLoader).from_string(template).render(data)
-
-
 def main():
     parser = argparse.ArgumentParser(description="Generate emails to bulk send later.")
     parser.add_argument("template", help="a Markdown formatted document with a YAML front-matter")
@@ -79,6 +75,13 @@ def main():
     if not os.path.exists(args.outbox):
         os.mkdir(args.outbox)
 
+    # jinja2 with builtin support (e.g. zip, len, max, ...)
+    env = jinja2.Environment(loader=jinja2.BaseLoader)
+    env.globals.update(__builtins__)
+
+    def render_template(template, data):
+        return env.from_string(template).render(data)
+
     count = 0
 
     for data in contacts:
@@ -88,7 +91,7 @@ def main():
 
         # Load the email text from after the front matter
         text = render_template(match.group(4), data)
-        html = markdown.markdown(text)
+        html = markdown.markdown(text, extensions=['tables'])
         html = BASE_HTML.format(body=html)
 
         msg = MIMEMultipart("alternative")


### PR DESCRIPTION
Support for calling python builtin functions from the jinja templates, allowing more dynamic mails. A possible use case is to build a table depending on a column of the CSV:

```
names,surnames,mails
Edo|Wil,Mora|DL,e@m.it|w@dl.it
```

```
| **Name** | **Surname** | **Mail** |
| -------- | ----------- | -------- |
{% for (name, surname, mail) in zip(names.split("|"), surnames.split("|"), mails.split("|")) -%}
| {{name}} | {{surname}} | {{mail}} |
{% endfor %}
```

(the strange newlines are there to avoid blank lines between the table rows)

I've built those CSV columns from Google Sheets, using more advanced tools (e.g. python) the builtins may be avoided, but they allow for more quick solutions.

Note that supporting the builtins may open some security concerns, among them there is `eval`, `open`, `file` and more. Most of the times the template string is trusted, therefore I don't really see this as a bit issue.