### PR TITLE
Nicer output with progress and debug view

### DIFF
--- a/mailipy/gen.py
+++ b/mailipy/gen.py
@@ -40,6 +40,7 @@ def main():
     parser.add_argument("template", help="a Markdown formatted document with a YAML front-matter")
     parser.add_argument("contacts", help="a CSV file with the contacts whom to send emails to")
     parser.add_argument("outbox", nargs="?", default="outbox", help="a folder where to save the emails (default: outbox)")
+    parser.add_argument("--print", "-p", action="store_true", help="print to stdout the rendered Markdown")
     args = parser.parse_args()
 
     if (not os.path.isfile(args.template)) or (not args.template.lower().endswith(".md")):
@@ -91,6 +92,10 @@ def main():
 
         # Load the email text from after the front matter
         text = render_template(match.group(4), data)
+        if args.print:
+            print(text)
+        else:
+            print("\r%4d / %4d" % (count + 1, len(contacts)), end="", flush=True)
         html = markdown.markdown(text, extensions=['tables'])
         html = BASE_HTML.format(body=html)
 
@@ -127,6 +132,8 @@ def main():
 
         count += 1
 
+    if not args.print:
+        print()  # The cursor is still at the middle of the line
     print("Created %d mails in '%s', ready to be sent" % (count, args.outbox))
 
 


### PR DESCRIPTION
When supplied with `-p` (or `--print`), the rendered markdown content is printed for each mail. Otherwise a nice progress meter showing the number of rendered mails.

Before timings
```
Created 421 mails in 'outbox', ready to be sent
3.17user 0.03system 0:03.21elapsed 99%CPU (0avgtext+0avgdata 28712maxresident)k
0inputs+13576outputs (0major+10725minor)pagefaults 0swaps
```

After timings (without `-p`)
```
Created 421 mails in 'outbox', ready to be sent
3.69user 0.06system 0:03.77elapsed 99%CPU (0avgtext+0avgdata 28452maxresident)k
0inputs+13576outputs (0major+10451minor)pagefaults 0swaps
```

![out](https://user-images.githubusercontent.com/6685454/95217253-4326dd80-07f3-11eb-8231-2833d8a598f6.GIF)
