### PR TITLE
Raise CSV limit

### DIFF
--- a/mailipy/gen.py
+++ b/mailipy/gen.py
@@ -38,7 +38,7 @@ BASE_HTML = """<!DOCTYPE html>
     </body>
 </html>"""
 
-csv.field_size_limit(sys.maxsize)
+csv.field_size_limit(10 * 1024 * 1024) # 10 MB
 
 
 def create_attachment(main_msg, file_path):

--- a/mailipy/gen.py
+++ b/mailipy/gen.py
@@ -38,6 +38,8 @@ BASE_HTML = """<!DOCTYPE html>
     </body>
 </html>"""
 
+csv.field_size_limit(sys.maxsize)
+
 
 def create_attachment(main_msg, file_path):
     content_type, _ = mimetypes.guess_type(file_path)


### PR DESCRIPTION
Allow the CSV fields to be as large as you want. The default limit is quite small (~130k), and this enables you to embed whatever you want in the CSV. This is especially useful if you want to have a JSON column to deserialize in the template, since every quote has to be quoted to be valid CSV.

I've found this in my local clone, so I guess it was used sometimes in the past.